### PR TITLE
Don't force 100% width on images

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -58,8 +58,8 @@ blockquote p {
 img {
     display: block;
     margin: 40px 0;
-    width: 100%;
-        max-width: 809px;
+    width: auto;
+    max-width: 100%;
 }
 
 pre {


### PR DESCRIPTION
A better way to prevent images from overflowing on smaller width's is to make their maximum width their container's, instead of forcing them to be as wide as it (to prevent up-scaling of smaller images).
