### PR TITLE
Making the loading of the font depend on the protocol

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -17,7 +17,7 @@
     <link rel="stylesheet" type="text/css" href="/assets/css/normalize.css" />
     <link rel="stylesheet" type="text/css" href="/assets/css/nprogress.css" />
     <link rel="stylesheet" type="text/css" href="/assets/css/style.css" />
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,600,700,300&subset=latin,cyrillic-ext,latin-ext,cyrillic" />
+    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,600,700,300&subset=latin,cyrillic-ext,latin-ext,cyrillic" />
 
     {{! Ghost outputs important style and meta data with this tag }}
     {{ghost_head}}


### PR DESCRIPTION
If a blog is served under https, then loading the fonts from http causes browsers to give "mixed-content" warnings (latest Chrome and Firefox). This change fixes this, by making the font be loaded from the same protocol that the page is being served.
