### PR TITLE
fix "About Page"'s link failed when blog has subpath

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -37,7 +37,7 @@
                 <ul class="site-nav">
                     <li class="site-nav-item"><a class="js-ajax-link" href="{{@blog.url}}">Latest Post</a></li>
                     <li class="site-nav-item"><a class="js-ajax-link js-show-index" href="{{@blog.url}}">Browse Posts</a></li>
-                    <li class="site-nav-item"><a class="js-ajax-link" href="/about">About</a></li>
+                    <li class="site-nav-item"><a class="js-ajax-link" href="{{@blog.url}}/about">About</a></li>
                 </ul>
             </div>
         </header>


### PR DESCRIPTION
Some ghost blog may have url subpath,default about path may not correct
For example :
http://www.xxx.com/blog
In this case,the url of the "About Page" is "http://www.xxx.com/blog/about" but isn't "http://www.xxx.com/about"
