### PR TITLE
Small change to get inline paragraphs when having a list element

### DIFF
--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -285,6 +285,8 @@ table {
     }
 
     &:last-child { margin-bottom: 0; }
+
+    li > p { display: inline; }
 }
 
 .post-footer { margin-top: 5px; }


### PR DESCRIPTION
I added a sass line for when ghost add paragraphs for the element of a list, then we have a block, and should be an inline element, otherwise the content jumps to a new line.

I didn't update the style.css, seems there are more changes to update there, so I think is better if you could review it. :-)
