### PR TITLE
Fix author-bio exceeding mobile screens

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -399,7 +399,7 @@ table {
 .author-bio {
   margin: 20px auto 0;
   text-align: center;
-  width: 700px; }
+  max-width: 700px; }
 
 /* ============================================================ */
 /* Footer */

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -453,7 +453,7 @@ table {
 .author-bio {
     margin: 20px auto 0;
     text-align: center;
-    width: 700px;
+    max-width: 700px;
 }
 
 /* ============================================================ */


### PR DESCRIPTION
The authorbio is set to 700px and on small screens like mobile ones it exceed the page width. Changing `widht: 700px` to `max-width: 700px` fixes the view on mobile screens and keeps the same behaviour on wider screens.
