### PR TITLE
fix keeping loading bug wher the url is 404

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -79,6 +79,10 @@ jQuery(function($) {
                 loading = false;
                 showIndex = false;
             });
+        }).fail(function() {
+            // Request fail
+            NProgress.done();
+            location.reload();
         });
     });
 


### PR DESCRIPTION
When a 404 error occurs, the page will keep loading.