### PR TITLE
Add internationalisation (i18n) support

### DIFF
--- a/author.hbs
+++ b/author.hbs
@@ -12,7 +12,7 @@
             </div>
 
             <div class="author-meta">
-                <span><i class="fa fa-bar-chart-o"></i> {{plural ../pagination.total empty='No posts' singular='% post' plural='% posts'}}</span>
+                <span><i class="fa fa-bar-chart-o"></i> {{plural ../pagination.total empty=(t "No posts") singular=(t "% post") plural=(t "% posts")}}</span>
                 {{#if location}}<span><i class="fa fa-map-marker"></i>{{location}}</span>{{/if}}
                 {{#if website}}<span><i class="fa fa-link"></i><a href="{{website}}">{{website}}</a></span>{{/if}}
                 <span><i class="fa fa-rss-square"></i><a href="{{url}}rss/">{{name}}</a></span>

--- a/default.hbs
+++ b/default.hbs
@@ -38,8 +38,8 @@
                 </div>
 
                 <ul class="site-nav">
-                    <li class="site-nav-item"><a class="js-ajax-link" title="{{@blog.title}}" href="{{@blog.url}}">Latest Post</a></li>
-                    <li class="site-nav-item"><a class="js-ajax-link js-show-index" title="{{@blog.title}}" href="{{@blog.url}}">Browse Posts</a></li>
+                    <li class="site-nav-item"><a class="js-ajax-link" title="{{@blog.title}}" href="{{@blog.url}}">{{t "Latest Post"}}</a></li>
+                    <li class="site-nav-item"><a class="js-ajax-link js-show-index" title="{{@blog.title}}" href="{{@blog.url}}">{{t "Browse Posts"}}</a></li>
 
                     {{navigation}}
 
@@ -63,7 +63,7 @@
                 <a class="button-square button-jump-top js-jump-top" href="#"><i class="fa fa-angle-up"></i></a>
             </div>
 
-            <p class="footer-copyright">&copy; {{date format="YYYY"}} / Published with <a href="https://ghost.org">Ghost</a> / <a href="https://github.com/roryg/ghostwriter">Ghostwriter theme</a> By <a href="http://jollygoodthemes.com">JollyGoodThemes</a></p>
+            <p class="footer-copyright">&copy; {{date format="YYYY"}} / {{{t "Published with {ghostlink}" ghostlink="<a href=\"https://ghost.org\">Ghost</a>"}}} / {{{t "{ghostwriterlink} theme by {jollygoodthemeslink}" ghostwriterlink="<a href=\"https://github.com/roryg/ghostwriter\">Ghostwriter</a>" jolygoodthemeslink="<a href=\"http://jollygoodthemes.com\">JollyGoodThemes</a>"}}}</p>
         </div>
     </footer>
 

--- a/default.hbs
+++ b/default.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{lang}}">
 <head>
     {{! Document Settings }}
     <meta http-equiv="Content-Type" content="text/html" charset="UTF-8" />
@@ -63,7 +63,7 @@
                 <a class="button-square button-jump-top js-jump-top" href="#"><i class="fa fa-angle-up"></i></a>
             </div>
 
-            <p class="footer-copyright">&copy; {{date format="YYYY"}} / {{{t "Published with {ghostlink}" ghostlink="<a href=\"https://ghost.org\">Ghost</a>"}}} / {{{t "{ghostwriterlink} theme by {jollygoodthemeslink}" ghostwriterlink="<a href=\"https://github.com/roryg/ghostwriter\">Ghostwriter</a>" jolygoodthemeslink="<a href=\"http://jollygoodthemes.com\">JollyGoodThemes</a>"}}}</p>
+            <p class="footer-copyright">&copy; {{date format="YYYY"}} / {{{t "Published with {ghostlink}" ghostlink="<a href=\"https://ghost.org\">Ghost</a>"}}} / {{{t "{ghostwriter} theme by {jollygoodthemes}" ghostwriter="<a href=\"https://github.com/roryg/ghostwriter\">Ghostwriter</a>" jollygoodthemes="<a href=\"http://jollygoodthemes.com\">JollyGoodThemes</a>"}}}</p>
         </div>
     </footer>
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -7,5 +7,8 @@
     "Posts tagged:": "Posts tagged:",
     "Featured": "Featured",
     "Published": "Published",
-    "by": "by"
+    "by": "by",
+    "No posts": "No posts",
+    "% post": "% post",
+    "% posts": "% posts"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,8 @@
 {
+    "Newer Posts": "Newer Posts",
+    "of": "of",
+    "Older Posts": "Older Posts",
+    "Page": "Page",
     "Latest Post": "Latest Post",
     "Browse Posts": "Browse Posts",
     "Published with {ghostlink}": "Published with {ghostlink}",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,11 @@
+{
+    "Latest Post": "Latest Post",
+    "Browse Posts": "Browse Posts",
+    "Published with {ghostlink}": "Published with {ghostlink}",
+    "{ghostwriter} theme by {jollygoodthemes}": "{ghostwriter} theme by {jollygoodthemes}",
+    "Tagged:": "Tagged:",
+    "Posts tagged:": "Posts tagged:",
+    "Featured": "Featured",
+    "Published": "Published",
+    "by": "by"
+}

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -7,5 +7,8 @@
     "Posts tagged:": "Articles étiquettés :",
     "Featured": "Épinglé",
     "Published": "Publié",
-    "by": "par"
+    "by": "par",
+    "No posts": "Pas d’article",
+    "% post": "% article",
+    "% posts": "% articles"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,0 +1,11 @@
+{
+    "Latest Post": "Dernier article",
+    "Browse Posts": "Parcourir les articles",
+    "Published with {ghostlink}": "Publié avec {ghostlink}",
+    "{ghostwriter} theme by {jollygoodthemes}": "Thème {ghostwriter} par {jollygoodthemes}",
+    "Tagged:": "Étiquetté :",
+    "Posts tagged:": "Articles étiquettés :",
+    "Featured": "Épinglé",
+    "Published": "Publié",
+    "by": "par"
+}

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,4 +1,8 @@
 {
+    "Newer Posts": "Plus récents",
+    "of": "sur",
+    "Older Posts": "Plus anciens",
+    "Page": "Page",
     "Latest Post": "Dernier article",
     "Browse Posts": "Parcourir les articles",
     "Published with {ghostlink}": "Publié avec {ghostlink}",

--- a/page.hbs
+++ b/page.hbs
@@ -18,7 +18,7 @@
 {{{content}}}
 
                 {{#if tags}}
-                    <p class="post-tags"><span>Tagged:</span> {{tags}}</p>
+                    <p class="post-tags"><span>{{t "Tagged:"}}</span> {{tags}}</p>
                 {{/if}}
             </div>
         </article>

--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -3,10 +3,10 @@
         <a class="js-ajax-link"  title="{{title}} | {{@blog.title}}" href="{{url}}">
             <h4 class="post-stub-title">{{title}}</h4>
 
-            <time class="post-stub-date" datetime="{{published_at}}">Published {{date format="MMMM Do YYYY"}}</time>
+            <time class="post-stub-date" datetime="{{published_at}}">{{t "Published"}} {{date published_at timeago="true"}}</time>
 
             {{#if featured}}
-                <span class="post-stub-tag">Featured</span>
+                <span class="post-stub-tag">{{t "Featured"}}</span>
             {{/if}}
         </a>
     </li>

--- a/partials/pagination.hbs
+++ b/partials/pagination.hbs
@@ -1,0 +1,9 @@
+<nav class="pagination" role="navigation">
+    {{#if prev}}
+        <a class="newer-posts" href="{{page_url prev}}"><span aria-hidden="true">&larr;</span> {{t "Newer Posts"}}</a>
+    {{/if}}
+    <span class="page-number">{{t "Page"}} {{page}} {{t "of"}} {{pages}}</span>
+    {{#if next}}
+        <a class="older-posts" href="{{page_url next}}">{{t "Older Posts"}} <span aria-hidden="true">&rarr;</span></a>
+    {{/if}}
+</nav>

--- a/partials/post-content.hbs
+++ b/partials/post-content.hbs
@@ -15,7 +15,7 @@
 
     <footer class="post-footer clearfix">
         {{#if tags}}
-            <p class="post-tags"><span>Tagged:</span> {{tags}}</p>
+            <p class="post-tags"><span>{{t "Tagged:"}}</span> {{tags}}</p>
         {{/if}}
 
         <div class="share">

--- a/partials/post-content.hbs
+++ b/partials/post-content.hbs
@@ -2,7 +2,7 @@
     <header class="post-header">
         <h1 class="post-title">{{title}}</h1>
 
-        <p class="post-date">Published <time datetime="{{published_at}}">{{date format="MMMM Do YYYY"}}</time> <strong>by {{author}}</strong></p>
+        <p class="post-date">{{t "Published"}} <time datetime="{{published_at}}">{{date published_at timeago="true"}}</time> <strong>{{t "by"}} {{author}}</strong></p>
     </header>
 
     <div class="post-content clearfix">

--- a/tag.hbs
+++ b/tag.hbs
@@ -1,7 +1,7 @@
 {{!< default}}
 
 <div class="container">
-    <h1 class="page-title">Posts tagged: {{tag.name}}</h1>
+    <h1 class="page-title">{{t "Posts tagged:"}} {{tag.name}}</h1>
 
     <ol class="post-list">
         {{> loop}}


### PR DESCRIPTION
Now that Ghost support to translate themes in any language, I've worked a bit on the theme to use the ```t``` [translation helper](https://themes.ghost.org/docs/t) and provide the first translation in French.

Everything works as before, but one thing: how dates are displayed on articles. I couldn't figure out (yet) how to cleanly internationalise the date, as the theme is using the american english ```MMMM Do YYYY```. Therefore, I propose to display dates with the ```timeago``` atttribute for now.

Fixes #90.