### PR TITLE
Ghost v3 compatibility

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -655,3 +655,85 @@ table {
     width: 100%;
     height: 100%;
 }
+
+.kg-bookmark-card {
+    width: 100%;
+    position: relative;
+}
+
+.kg-bookmark-container {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row-reverse;
+    color: currentColor;
+    font-family: inherit;
+    text-decoration: none;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.kg-bookmark-container:hover {
+    text-decoration: none;
+}
+
+.kg-bookmark-content {
+    flex-basis: 0;
+    flex-grow: 999;
+    padding: 20px;
+    order: 1;
+}
+
+.kg-bookmark-title {
+    font-weight: 600;
+}
+
+.kg-bookmark-metadata,
+.kg-bookmark-description {
+    margin-top: .5em;
+}
+
+.kg-bookmark-metadata {
+    align-items: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.kg-bookmark-description {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+}
+
+.kg-bookmark-icon {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    vertical-align: text-bottom;
+    margin-right: .5em;
+    margin-bottom: .05em;
+}
+
+.kg-bookmark-thumbnail {
+    display: flex;
+    flex-basis: 24rem;
+    flex-grow: 1;
+}
+
+.kg-bookmark-thumbnail img {
+    max-width: 100%;
+    height: auto;
+    vertical-align: bottom;
+    object-fit: cover;
+}
+
+.kg-bookmark-author {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+
+.kg-bookmark-publisher::before {
+    content: "•";
+    margin: 0 .5em;
+}

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,15 @@
 ------------------------------
+Ghostwriter Version 1.9.5
+------------------------------
+- (tylerfontaine) added ghost v3 compatibility
+
+------------------------------
+Ghostwriter Version 1.9.4
+------------------------------
+
+- (tylerfontaine) added ghost v2 compatibility
+
+------------------------------
 Ghostwriter Version 1.9.3
 ------------------------------
 
@@ -82,7 +93,7 @@ Ghostwriter Version 1.4.0
 - Added basic support for html tables
 - Added fitvid.js for responsive video support
 - Removed image icons
-- Replaced the browse posts button with a Browse Posts text link in 
+- Replaced the browse posts button with a Browse Posts text link in
   the new navigation menu. This should make finding the posts list
   easier for users.
 - Tidied up nested lists

--- a/default.hbs
+++ b/default.hbs
@@ -28,23 +28,23 @@
         <header class="site-header">
             <div class="container">
                 <div class="site-title-wrapper">
-                    {{#if @blog.logo}}
-                        <a class="site-logo js-ajax-link" title="{{@blog.title}}" href="{{@blog.url}}"><img src="{{@blog.logo}}" alt="{{@blog.title}}" /></a>
+                    {{#if @site.logo}}
+                        <a class="site-logo js-ajax-link" title="{{@site.title}}" href="{{@site.url}}"><img src="{{@site.logo}}" alt="{{@site.title}}" /></a>
                     {{else}}
-                        <h1 class="site-title"><a class="js-ajax-link" title="{{@blog.title}}" href="{{@blog.url}}">{{@blog.title}}</a></h1>
+                        <h1 class="site-title"><a class="js-ajax-link" title="{{@site.title}}" href="{{@site.url}}">{{@site.title}}</a></h1>
 
-                        <a class="button-square" href="{{@blog.url}}/rss"><i class="fa fa-rss"></i></a>
+                        <a class="button-square" href="{{@site.url}}/rss"><i class="fa fa-rss"></i></a>
                     {{/if}}
                 </div>
 
                 <ul class="site-nav">
-                    <li class="site-nav-item"><a class="js-ajax-link" title="{{@blog.title}}" href="{{@blog.url}}">Latest Post</a></li>
-                    <li class="site-nav-item"><a class="js-ajax-link js-show-index" title="{{@blog.title}}" href="{{@blog.url}}">Browse Posts</a></li>
+                    <li class="site-nav-item"><a class="js-ajax-link" title="{{@site.title}}" href="{{@site.url}}">Latest Post</a></li>
+                    <li class="site-nav-item"><a class="js-ajax-link js-show-index" title="{{@site.title}}" href="{{@site.url}}">Browse Posts</a></li>
 
                     {{navigation}}
 
-                    {{#if @blog.logo}}
-                        <li class="site-nav-item"><a href="{{@blog.url}}/rss">RSS</a></li>
+                    {{#if @site.logo}}
+                        <li class="site-nav-item"><a href="{{@site.url}}/rss">RSS</a></li>
                     {{/if}}
                 </ul>
             </div>
@@ -58,7 +58,7 @@
     <footer class="footer">
         <div class="container">
             <div class="site-title-wrapper">
-                <h1 class="site-title"><a class="js-ajax-link" title="{{@blog.title}}" href="{{@blog.url}}">{{@blog.title}}</a></h1>
+                <h1 class="site-title"><a class="js-ajax-link" title="{{@site.title}}" href="{{@site.url}}">{{@site.title}}</a></h1>
 
                 <a class="button-square button-jump-top js-jump-top" href="#"><i class="fa fa-angle-up"></i></a>
             </div>

--- a/package.json
+++ b/package.json
@@ -1,15 +1,14 @@
 {
-	"name": "ghostwriter",
-	"version": "1.9.5",
-	"engines": {
-        "ghost-api": "v3"
-    },
-    "author": {
-        "email": "rg.rorygibson+ghost@gmail.com"
-    },
-    "config": {
-        "posts_per_page": 5
-    },
-    "keywords": ["ghost-theme"]
-
+  "name": "ghostwriter",
+  "version": "1.9.5",
+  "engines": {
+    "ghost-api": "v3"
+  },
+  "author": {
+    "email": "rg.rorygibson+ghost@gmail.com"
+  },
+  "config": {
+    "posts_per_page": 5
+  },
+  "keywords": ["ghost-theme"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
 	"name": "ghostwriter",
 	"version": "1.9.4",
+	"engines": {
+        "ghost-api": "v3"
+    },
     "author": {
         "email": "rg.rorygibson+ghost@gmail.com"
     },
@@ -8,4 +11,5 @@
         "posts_per_page": 5
     },
     "keywords": ["ghost-theme"]
+
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ghostwriter",
-	"version": "1.9.4",
+	"version": "1.9.5",
 	"engines": {
         "ghost-api": "v3"
     },

--- a/page.hbs
+++ b/page.hbs
@@ -6,7 +6,7 @@
             <header class="post-header">
                 <h1 class="post-title">{{title}}</h1>
 
-                <p class="blog-description">{{@blog.description}}</p>
+                <p class="blog-description">{{@site.description}}</p>
             </header>
 
             <div class="post-content clearfix">

--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -1,6 +1,6 @@
 {{#foreach posts}}
     <li class="post-stub {{post_class}}" >
-        <a class="js-ajax-link"  title="{{title}} | {{@blog.title}}" href="{{url}}">
+        <a class="js-ajax-link"  title="{{title}} | {{@site.title}}" href="{{url}}">
             <h4 class="post-stub-title">{{title}}</h4>
 
             <time class="post-stub-date" datetime="{{published_at}}">Published {{date format="MMMM Do YYYY"}}</time>

--- a/partials/navigation.hbs
+++ b/partials/navigation.hbs
@@ -1,3 +1,3 @@
 {{#foreach navigation}}
-    <li class="site-nav-item"><a class="js-ajax-link" title="{{label}} | {{@blog.title}}" href="{{url absolute="true"}}">{{label}}</a></li>
+    <li class="site-nav-item"><a class="js-ajax-link" title="{{label}} | {{@site.title}}" href="{{url absolute="true"}}">{{label}}</a></li>
 {{/foreach}}


### PR DESCRIPTION
Updated `@blog` references to `@site` for v3 compatibility. 

Also added additional koenig styles for v3 compatibility. 

This is NOT backward compatible to v2, due to the `@site` change. Worth noting `@blog` is deprecated, but not yet removed. Will be removed in v4

Passes tests on https://gscan.ghost.org/ and is currently running on my site.